### PR TITLE
register modal no longer resizes

### DIFF
--- a/public/scripts/controllers/loginController.js
+++ b/public/scripts/controllers/loginController.js
@@ -4,6 +4,7 @@ myApp.controller('LoginController', ['$scope', 'UserService', '$mdDialog', '$mdM
     $scope.UserService = UserService;
     $scope.loginErrorMessage;
     $scope.loggedInUser;
+    $scope.password_confirm;
 
     $scope.login = function(isValid) {
         if (isValid) {

--- a/public/views/templates/register.html
+++ b/public/views/templates/register.html
@@ -1,6 +1,6 @@
-<div layout="row" layout-align="center" ng-cloak class="md-inline-form">
-    <md-content layout-padding>
-        <div>
+<md-dialog class="md-padding">
+    <md-dialog-content class="loginModal">
+        <div ng-cloak class="md-inline-form">
         <form name="registerForm" novalidate ng-submit="register(registerForm.$valid)">
             <div layout-lg="row">
                 <md-input-container class="md-block">
@@ -34,18 +34,19 @@
             </div>
             <div layout-lg="row">
                 <md-input-container class="md-block">
-                    <label>Password Confirm</label>
-                    <input type="password" name="password_confirm" required ng-model="password_confirm"
+                    <label>Confirm Password</label>
+                    <input type="password" name="password_confirm" required ng-model="password_confirm" ng-model-options="{ debounce: 750 }"
                            wj-validation-error="password != password_confirm ? 'Passwords don\'t match' : ''" />
-                    <div ng-show="registerForm.password_confirm.$error.wjValidationError && !registerForm.password_confirm.$pristine">
+                    <div class="error-message"
+                            ng-if="registerForm.password_confirm.$invalid && !registerForm.password_confirm.$pristine">
                         Sorry, the passwords don't match.
                     </div>
                 </md-input-container>
             </div><br />
             <div layout-lg="row">
-                <p><md-button type="submit" class="md-raised md-primary" ng-disabled="register.$invalid">Register</md-button></p>
+                <p><md-button type="submit" class="md-raised md-primary" ng-disabled="registerForm.$invalid">Register</md-button></p>
             </div>
             </form>
         </div>
-    </md-content>
-</div>
+    </md-dialog-content>
+</md-dialog>


### PR DESCRIPTION
Upon registering, the modal no longer resizes itself and the message regarding an incorrect password confirmation is only shown when that event occurs.
Also, register modal size in more inline with login modal size now.
